### PR TITLE
Implement Tackler-Mk1 (and JDK) comp. regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,6 +1969,9 @@ version = "0.7.0-dev"
 dependencies = [
  "indoc",
  "log",
+ "regex",
+ "serde",
+ "serde_json",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,16 +1793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,7 +1921,6 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "serde_regex",
  "tackler-rs",
  "time",
  "time-tz",

--- a/README.adoc
+++ b/README.adoc
@@ -7,14 +7,15 @@ image:https://tackler.e257.fi/img/badge-matrix.svg["matrix: tackler", link="http
 
 = Tackler-NG
 
-Tackler is fast, reliable bookkeeping engine with native
-GIT SCM support for plain text accounting written in rust.
-Tackler-NG is rusty version of link:https://tackler.e257.fi/[Tackler].
+link:https://tackler.e257.fi/[Tackler] is fast, reliable bookkeeping engine
+with native GIT SCM support for plain text accounting, written in Rust.
+
 
 == Project Status
 
-The rusty Tackler-NG is in link:https://tackler.e257.fi/features/[feature] parity with the old scala based Tackler CLI,
-and this will be the basis of all future Tackler development.
+Tackler-NG is in link:https://tackler.e257.fi/features/[feature] parity with the old scala 
+based Tackler CLI, and Tackler-NG will be the basis of all future Tackler development.
+
 
 [NOTE]
 ====

--- a/tackler-api/CRATES.md
+++ b/tackler-api/CRATES.md
@@ -1,6 +1,9 @@
 # Tackler-NG: Client API
 
-This is rusty version of [Tackler](https://tackler.e257.fi/) Client API.
+[Tackler](https://tackler.e257.fi/) is fast, reliable bookkeeping tool
+with native GIT SCM support for plain text accounting, written in Rust.
+
+This crate is [Tackler](https://tackler.e257.fi/) Client API.
 
 
 ## Tackler components on Crates.io

--- a/tackler-api/Cargo.toml
+++ b/tackler-api/Cargo.toml
@@ -37,12 +37,11 @@ regex = { workspace = true }
 rust_decimal = { workspace = true }
 serde = { workspace = true, features = [ "derive"] }
 serde_json = { workspace = true }
-serde_regex = "1.1.0"
+tackler-rs = { path = "../tackler-rs", version = "0.7.0-dev" }
 time = { workspace = true, features = [ "serde-human-readable", "formatting", "parsing" ] }
 time-tz = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
 rust_decimal_macros = { workspace = true }
-tackler-rs = { path = "../tackler-rs", version = "0.7.0-dev" }
 indoc = { workspace = true }

--- a/tackler-api/src/filters/posting/posting_amount_greater.rs
+++ b/tackler-api/src/filters/posting/posting_amount_greater.rs
@@ -19,6 +19,8 @@ use regex::Regex;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
+use tackler_rs::regex::peeled_pattern;
+use tackler_rs::regex::serde::full_haystack_matcher;
 
 use crate::filters::{posting_filter_indent_fmt, IndentDisplay};
 
@@ -38,7 +40,7 @@ use crate::filters::{posting_filter_indent_fmt, IndentDisplay};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TxnFilterPostingAmountGreater {
     #[doc(hidden)]
-    #[serde(with = "serde_regex")]
+    #[serde(with = "full_haystack_matcher")]
     pub regex: Regex,
     #[doc(hidden)]
     #[serde(with = "rust_decimal::serde::arbitrary_precision")]
@@ -50,7 +52,7 @@ impl IndentDisplay for TxnFilterPostingAmountGreater {
         posting_filter_indent_fmt(
             indent,
             "Posting Amount",
-            self.regex.as_str(),
+            peeled_pattern(&self.regex),
             ">",
             &self.amount,
             f,
@@ -63,8 +65,32 @@ mod tests {
     use super::*;
     use crate::filters::{logic::TxnFilterAND, FilterDefinition, NullaryTRUE, TxnFilter};
     use indoc::indoc;
-    use regex::Regex;
+
+    use tackler_rs::regex::new_full_haystack_regex;
     use tackler_rs::IndocUtils;
+
+    #[test]
+    // test: 8609eb58-f600-42d1-a20a-c7de2c57e6e2
+    // desc: PostingAmountGreater, full haystack match
+    fn posting_amount_greater_full_haystack() {
+        let filter_json_str =
+            r#"{"txnFilter":{"TxnFilterPostingAmountGreater":{"regex":"o.a","amount":1}}}"#;
+
+        let tf_res = serde_json::from_str::<FilterDefinition>(filter_json_str);
+        assert!(tf_res.is_ok());
+        let tf = tf_res.unwrap(/*:test:*/);
+
+        match &tf.txn_filter {
+            TxnFilter::TxnFilterPostingAmountGreater(f) => {
+                assert!(!f.regex.is_match("foobar"));
+                assert!(!f.regex.is_match("obar"));
+                assert!(!f.regex.is_match("ooba"));
+
+                assert!(f.regex.is_match("oba"));
+            }
+            _ => panic!(/*:test:*/),
+        }
+    }
 
     #[test]
     // test: 66d6ee10-a18e-4615-9e7a-1569c793fe46
@@ -118,14 +144,14 @@ mod tests {
             txn_filter: TxnFilter::TxnFilterAND(TxnFilterAND {
                 txn_filters: vec![
                     TxnFilter::TxnFilterPostingAmountGreater(TxnFilterPostingAmountGreater {
-                        regex: Regex::new("(abc.*)|(def.*)").unwrap(/*:test:*/),
+                        regex: new_full_haystack_regex("(abc.*)|(def.*)").unwrap(/*:test:*/),
                         amount: Decimal::from(1),
                     }),
                     TxnFilter::TxnFilterAND(TxnFilterAND {
                         txn_filters: vec![
                             TxnFilter::TxnFilterPostingAmountGreater(
                                 TxnFilterPostingAmountGreater {
-                                    regex: Regex::new("xyz").unwrap(/*:test:*/),
+                                    regex: new_full_haystack_regex("xyz").unwrap(/*:test:*/),
                                     amount: Decimal::from(2),
                                 },
                             ),

--- a/tackler-api/src/filters/posting/posting_comment.rs
+++ b/tackler-api/src/filters/posting/posting_comment.rs
@@ -18,6 +18,8 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
+use tackler_rs::regex::peeled_pattern;
+use tackler_rs::regex::serde::full_haystack_matcher;
 
 use crate::filters::IndentDisplay;
 
@@ -27,13 +29,17 @@ use crate::filters::IndentDisplay;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TxnFilterPostingComment {
     #[doc(hidden)]
-    #[serde(with = "serde_regex")]
+    #[serde(with = "full_haystack_matcher")]
     pub regex: Regex,
 }
 
 impl IndentDisplay for TxnFilterPostingComment {
     fn i_fmt(&self, indent: &str, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{indent}Posting Comment: \"{}\"", self.regex.as_str())
+        writeln!(
+            f,
+            "{indent}Posting Comment: \"{}\"",
+            peeled_pattern(&self.regex)
+        )
     }
 }
 
@@ -42,8 +48,31 @@ mod tests {
     use super::*;
     use crate::filters::{logic::TxnFilterAND, FilterDefinition, NullaryTRUE, TxnFilter};
     use indoc::indoc;
-    use regex::Regex;
+
+    use tackler_rs::regex::new_full_haystack_regex;
     use tackler_rs::IndocUtils;
+
+    #[test]
+    // test: df851a3a-80b8-49ca-9dfa-f7b5ce122ddf
+    // desc: PostingComment, full haystack match
+    fn posting_comment_full_haystack() {
+        let filter_json_str = r#"{"txnFilter":{"TxnFilterPostingComment":{"regex":"o.a"}}}"#;
+
+        let tf_res = serde_json::from_str::<FilterDefinition>(filter_json_str);
+        assert!(tf_res.is_ok());
+        let tf = tf_res.unwrap(/*:test:*/);
+
+        match &tf.txn_filter {
+            TxnFilter::TxnFilterPostingComment(f) => {
+                assert!(!f.regex.is_match("foobar"));
+                assert!(!f.regex.is_match("obar"));
+                assert!(!f.regex.is_match("ooba"));
+
+                assert!(f.regex.is_match("oba"));
+            }
+            _ => panic!(/*:test:*/),
+        }
+    }
 
     #[test]
     // test: 55401f74-0054-42ec-ab0b-17d4c9cda0be
@@ -92,12 +121,12 @@ mod tests {
             txn_filter: TxnFilter::TxnFilterAND(TxnFilterAND {
                 txn_filters: vec![
                     TxnFilter::TxnFilterPostingComment(TxnFilterPostingComment {
-                        regex: Regex::new("(abc.*)|(def.*)").unwrap(/*:test:*/),
+                        regex: new_full_haystack_regex("(abc.*)|(def.*)").unwrap(/*:test:*/),
                     }),
                     TxnFilter::TxnFilterAND(TxnFilterAND {
                         txn_filters: vec![
                             TxnFilter::TxnFilterPostingComment(TxnFilterPostingComment {
-                                regex: Regex::new("xyz").unwrap(/*:test:*/),
+                                regex: new_full_haystack_regex("xyz").unwrap(/*:test:*/),
                             }),
                             TxnFilter::NullaryTRUE(NullaryTRUE {}),
                         ],

--- a/tackler-api/src/filters/posting/posting_commodity.rs
+++ b/tackler-api/src/filters/posting/posting_commodity.rs
@@ -18,6 +18,8 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
+use tackler_rs::regex::peeled_pattern;
+use tackler_rs::regex::serde::full_haystack_matcher;
 
 use crate::filters::IndentDisplay;
 
@@ -27,13 +29,17 @@ use crate::filters::IndentDisplay;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TxnFilterPostingCommodity {
     #[doc(hidden)]
-    #[serde(with = "serde_regex")]
+    #[serde(with = "full_haystack_matcher")]
     pub regex: Regex,
 }
 
 impl IndentDisplay for TxnFilterPostingCommodity {
     fn i_fmt(&self, indent: &str, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{indent}Posting Commodity: \"{}\"", self.regex.as_str())
+        writeln!(
+            f,
+            "{indent}Posting Commodity: \"{}\"",
+            peeled_pattern(&self.regex)
+        )
     }
 }
 
@@ -42,8 +48,31 @@ mod tests {
     use super::*;
     use crate::filters::{logic::TxnFilterAND, FilterDefinition, NullaryTRUE, TxnFilter};
     use indoc::indoc;
-    use regex::Regex;
+
+    use tackler_rs::regex::new_full_haystack_regex;
     use tackler_rs::IndocUtils;
+
+    #[test]
+    // test: d2fbabba-f37c-4245-bf7a-0fed4db82695
+    // desc: PostingCommodity, full haystack match
+    fn posting_commodity_full_haystack() {
+        let filter_json_str = r#"{"txnFilter":{"TxnFilterPostingCommodity":{"regex":"o.a"}}}"#;
+
+        let tf_res = serde_json::from_str::<FilterDefinition>(filter_json_str);
+        assert!(tf_res.is_ok());
+        let tf = tf_res.unwrap(/*:test:*/);
+
+        match &tf.txn_filter {
+            TxnFilter::TxnFilterPostingCommodity(f) => {
+                assert!(!f.regex.is_match("foobar"));
+                assert!(!f.regex.is_match("obar"));
+                assert!(!f.regex.is_match("ooba"));
+
+                assert!(f.regex.is_match("oba"));
+            }
+            _ => panic!(/*:test:*/),
+        }
+    }
 
     #[test]
     // test: b7b43b0f-0046-4d25-8f61-2ef419b84f0b
@@ -92,12 +121,12 @@ mod tests {
             txn_filter: TxnFilter::TxnFilterAND(TxnFilterAND {
                 txn_filters: vec![
                     TxnFilter::TxnFilterPostingCommodity(TxnFilterPostingCommodity {
-                        regex: Regex::new("(abc.*)|(def.*)").unwrap(/*:test:*/),
+                        regex: new_full_haystack_regex("(abc.*)|(def.*)").unwrap(/*:test:*/),
                     }),
                     TxnFilter::TxnFilterAND(TxnFilterAND {
                         txn_filters: vec![
                             TxnFilter::TxnFilterPostingCommodity(TxnFilterPostingCommodity {
-                                regex: Regex::new("xyz").unwrap(/*:test:*/),
+                                regex: new_full_haystack_regex("xyz").unwrap(/*:test:*/),
                             }),
                             TxnFilter::NullaryTRUE(NullaryTRUE {}),
                         ],

--- a/tackler-api/src/filters/txn/txn_description.rs
+++ b/tackler-api/src/filters/txn/txn_description.rs
@@ -18,6 +18,8 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
+use tackler_rs::regex::peeled_pattern;
+use tackler_rs::regex::serde::full_haystack_matcher;
 
 use crate::filters::IndentDisplay;
 
@@ -27,13 +29,17 @@ use crate::filters::IndentDisplay;
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TxnFilterTxnDescription {
     #[doc(hidden)]
-    #[serde(with = "serde_regex")]
+    #[serde(with = "full_haystack_matcher")]
     pub regex: Regex,
 }
 
 impl IndentDisplay for TxnFilterTxnDescription {
     fn i_fmt(&self, indent: &str, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{indent}Txn Description: \"{}\"", self.regex.as_str())
+        writeln!(
+            f,
+            "{indent}Txn Description: \"{}\"",
+            peeled_pattern(&self.regex)
+        )
     }
 }
 
@@ -42,8 +48,31 @@ mod tests {
     use super::*;
     use crate::filters::{logic::TxnFilterAND, FilterDefinition, NullaryTRUE, TxnFilter};
     use indoc::indoc;
-    use regex::Regex;
+
+    use tackler_rs::regex::new_full_haystack_regex;
     use tackler_rs::IndocUtils;
+
+    #[test]
+    // test: f2a52f9d-1fd6-428d-9bb4-7821d1f15ce3
+    // desc: TxnDescription, full haystack match
+    fn txn_description_full_haystack() {
+        let filter_json_str = r#"{"txnFilter":{"TxnFilterTxnDescription":{"regex":"o.a"}}}"#;
+
+        let tf_res = serde_json::from_str::<FilterDefinition>(filter_json_str);
+        assert!(tf_res.is_ok());
+        let tf = tf_res.unwrap(/*:test:*/);
+
+        match &tf.txn_filter {
+            TxnFilter::TxnFilterTxnDescription(f) => {
+                assert!(!f.regex.is_match("foobar"));
+                assert!(!f.regex.is_match("obar"));
+                assert!(!f.regex.is_match("ooba"));
+
+                assert!(f.regex.is_match("oba"));
+            }
+            _ => panic!(/*:test:*/),
+        }
+    }
 
     #[test]
     // test: 9cb8321a-0c43-4a24-b21e-0286dbe503cd
@@ -92,12 +121,12 @@ mod tests {
             txn_filter: TxnFilter::TxnFilterAND(TxnFilterAND {
                 txn_filters: vec![
                     TxnFilter::TxnFilterTxnDescription(TxnFilterTxnDescription {
-                        regex: Regex::new("(abc.*)|(def.*)").unwrap(/*:test:*/),
+                        regex: new_full_haystack_regex("(abc.*)|(def.*)").unwrap(/*:test:*/),
                     }),
                     TxnFilter::TxnFilterAND(TxnFilterAND {
                         txn_filters: vec![
                             TxnFilter::TxnFilterTxnDescription(TxnFilterTxnDescription {
-                                regex: Regex::new("xyz").unwrap(/*:test:*/),
+                                regex: new_full_haystack_regex("xyz").unwrap(/*:test:*/),
                             }),
                             TxnFilter::NullaryTRUE(NullaryTRUE {}),
                         ],

--- a/tackler-cli/CRATES.md
+++ b/tackler-cli/CRATES.md
@@ -8,15 +8,13 @@
 [![Chat on Matrix](https://tackler.e257.fi/img/badge-matrix.svg)](https://matrix.to/#/#tackler:matrix.org)
 
 
-Tackler is fast, reliable bookkeeping tool with native GIT SCM 
-support for plain text accounting written in rust. 
-Tackler-NG is rusty version of [Tackler](https://tackler.e257.fi/).
+[Tackler](https://tackler.e257.fi/) is fast, reliable bookkeeping tool
+with native GIT SCM  support for plain text accounting, written in Rust. 
 
 ## Project Status
 
-The rusty Tackler-NG is in [feature](https://tackler.e257.fi/features/)
-parity with old scala based Tackler CLI, and it is 
-the basis of all future Tackler development.
+Tackler-NG is in [feature](https://tackler.e257.fi/features/) parity with the old scala 
+based Tackler CLI, and Tackler-NG will be the basis of all future Tackler development.
 
 **NOTE: Tackler-NG is tested with 284 of tackler's test vectors at the moment**
 

--- a/tackler-core/CRATES.md
+++ b/tackler-core/CRATES.md
@@ -1,6 +1,9 @@
 # Tackler-NG: Server API
 
-This is rusty version of [Tackler](https://tackler.e257.fi/) Server API.
+[Tackler](https://tackler.e257.fi/) is fast, reliable bookkeeping tool
+with native GIT SCM support for plain text accounting, written in Rust.
+
+This crate is [Tackler](https://tackler.e257.fi/) Server API.
 
 
 ## Tackler components on Crates.io

--- a/tackler-rs/CRATES.md
+++ b/tackler-rs/CRATES.md
@@ -9,6 +9,30 @@ The Rusty Services are assorted bits and pieces which are needed for
 Tackler, but won't fit into the domain of plain text accounting.
 
 
+## Full haystack regex matchers
+
+By default Rust `regex::Regex::is_match` will test if there is a match for the regex [anywhere in the haystack](https://docs.rs/regex/latest/regex/struct.Regex.html#method.is_match) given.
+
+These constructors create a regex which will try to match against the full haystack by default. This logic is similar than [java.util.regex.Matcher.matches()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Matcher.html#matches())
+
+```rust
+tackler_rs::regex::{
+    new_full_haystack_regex,
+    new_full_haystack_regex_set,
+    peeled_pattern,
+    peeled_patterns
+}
+```
+
+### Serializers and Deserializers for full haystack matchers
+
+This is serializer and deserializer implementation of full haystack matcher for Serde.
+
+```rust
+tackler_rs::regex::serde::full_haystack_matcher
+```
+
+
 ## Tackler components on Crates.io
 
 * Tackler CLI application: [tackler](https://crates.io/crates/tackler)

--- a/tackler-rs/CRATES.md
+++ b/tackler-rs/CRATES.md
@@ -1,9 +1,12 @@
 # Tackler-NG: Rusty Services
 
-These are rusty services for [Tackler](https://tackler.e257.fi/).
+[Tackler](https://tackler.e257.fi/) is fast, reliable bookkeeping tool 
+with native GIT SCM support for plain text accounting, written in Rust.
 
-The rusty services are assorted bits and pieces which are needed for 
-rusty Tackler, but won't fit into the domain of plain text accounting.
+These are Rusty Services for [Tackler CLI](https://crates.io/crates/tackler).
+
+The Rusty Services are assorted bits and pieces which are needed for 
+Tackler, but won't fit into the domain of plain text accounting.
 
 
 ## Tackler components on Crates.io

--- a/tackler-rs/Cargo.toml
+++ b/tackler-rs/Cargo.toml
@@ -34,5 +34,10 @@ path = "src/lib.rs"
 [dependencies]
 indoc.workspace = true
 log = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = [ "std", "derive"] }
 walkdir = "2.5.0"
+
+[dev-dependencies]
+serde_json = { workspace = true }
 

--- a/tackler-rs/README.adoc
+++ b/tackler-rs/README.adoc
@@ -1,7 +1,7 @@
 = Tackler-NG: Rusty Services
 
-These are rusty services for Tackler.
+These are Rusty Services for Tackler.
 
-The rusty services are assorted bits and pieces which are
-needed for  rusty Tackler, but won't fit into the domain of
+The Rusty Services are assorted bits and pieces which are
+needed for Tackler, but won't fit into the domain of
 plain text accounting.

--- a/tackler-rs/src/lib.rs
+++ b/tackler-rs/src/lib.rs
@@ -30,6 +30,9 @@ use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use walkdir::{DirEntry, WalkDir};
 
+/// Regex helpers to have full haystack matcher (JDK matches())
+pub mod regex;
+
 ///
 /// Get full path based on
 /// directory, filename prefix, filename and extension

--- a/tackler-rs/src/regex.rs
+++ b/tackler-rs/src/regex.rs
@@ -1,0 +1,50 @@
+/*
+ * This file is licensed under either of
+ *  - Apache License, Version 2.0
+ * OR
+ *  - MIT license
+ * at your option.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ **************************************************************************
+ *
+ * Apache License header
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */

--- a/tackler-rs/src/regex.rs
+++ b/tackler-rs/src/regex.rs
@@ -48,3 +48,205 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+/// Serialization and Deserialization for full haystack regex matchers
+pub mod serde;
+
+use regex::{Regex, RegexSet};
+
+fn into_full_haystack_pattern<S>(re: S) -> String
+where
+    S: AsRef<str>,
+{
+    format!("^(?:{})$", re.as_ref())
+}
+
+fn peel_full_haystack_pattern(re: &str) -> &str {
+    match re.strip_prefix("^(?:") {
+        Some(prefix_clean) => prefix_clean.strip_suffix(r")$").unwrap_or(re),
+        None => re,
+    }
+}
+
+/// Compiles a full haystack regular expression
+///
+/// This will augment (anchor) the given re so that it will match against
+/// full haystack.
+///
+/// See `Regex::Regex::new` for actual documentation of this method.
+///
+/// See `peeled_pattern_as_str` how to get back the original string
+///
+/// # Examples
+/// ```rust
+/// # use std::error::Error;
+/// use tackler_rs::regex::new_full_haystack_regex;
+///
+/// let re_foo = new_full_haystack_regex("foo")?;
+/// let re_bar = new_full_haystack_regex("bar")?;
+///
+/// assert!(re_foo.is_match("foo"));
+/// assert!(re_bar.is_match("bar"));
+///
+/// assert!(!re_foo.is_match("foobar"));
+/// assert!(!re_bar.is_match("foobar"));
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
+pub fn new_full_haystack_regex(re: &str) -> Result<Regex, regex::Error> {
+    Regex::new(into_full_haystack_pattern(re).as_str())
+}
+
+/// Returns the original string of this regex.
+/// # Examples
+/// ```rust
+/// # use std::error::Error;
+/// use tackler_rs::regex::new_full_haystack_regex;
+/// use tackler_rs::regex::peeled_pattern;
+///
+/// let re_foo = new_full_haystack_regex(r"foo.*")?;
+///
+/// assert_eq!(peeled_pattern(&re_foo), r"foo.*");
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
+pub fn peeled_pattern(regex: &Regex) -> &str {
+    peel_full_haystack_pattern(regex.as_str())
+}
+
+/// Compiles a set of full haystack regular expressions
+///
+/// This will augment (anchor) the given expressions so
+/// that each of those will match against full haystack.
+///
+/// See `Regex::RegexSet::new` for actual documentation of this method.
+///
+/// See `peeled_pattern` how to get back the original string
+///
+/// # Examples
+/// ```rust
+/// # use std::error::Error;
+/// use tackler_rs::regex::new_full_haystack_regex_set;
+///
+/// let re_set = new_full_haystack_regex_set(["foo", "bar"])?;
+///
+/// assert!(re_set.is_match("foo"));
+/// assert!(re_set.is_match("bar"));
+///
+/// assert!(!re_set.is_match("foobar"));
+/// assert!(!re_set.is_match("foobar"));
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
+pub fn new_full_haystack_regex_set<I, S>(exprs: I) -> Result<RegexSet, regex::Error>
+where
+    S: AsRef<str>,
+    I: IntoIterator<Item = S>,
+{
+    RegexSet::new(exprs.into_iter().map(|re| into_full_haystack_pattern(re)))
+}
+
+/// Returns the peeled regex patterns that this regex set was constructed from.
+///
+/// # Examples
+/// ```rust
+/// # use std::error::Error;
+/// use tackler_rs::regex::new_full_haystack_regex_set;
+/// use tackler_rs::regex::peeled_patterns;
+///
+/// let re_set = new_full_haystack_regex_set(["foo", "bar"])?;
+///
+/// assert_eq!(peeled_patterns(&re_set), vec!["foo", "bar"]);
+/// # Ok::<(), Box<dyn Error>>(())
+/// ```
+pub fn peeled_patterns(regex_set: &RegexSet) -> Vec<String> {
+    regex_set
+        .patterns()
+        .iter()
+        .map(|re| peel_full_haystack_pattern(re).to_string())
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peel_full_haystack_pattern() {
+        assert_eq!(peel_full_haystack_pattern("abc"), "abc");
+        assert_eq!(peel_full_haystack_pattern(".*"), ".*");
+        assert_eq!(peel_full_haystack_pattern("(.*)"), "(.*)");
+        assert_eq!(peel_full_haystack_pattern("^(?:.*)"), "^(?:.*)");
+        assert_eq!(peel_full_haystack_pattern("(.*)$"), "(.*)$");
+        assert_eq!(peel_full_haystack_pattern("^(?:.*)$"), ".*");
+    }
+
+    #[test]
+    fn test_full_haystack_pattern() {
+        let re = new_full_haystack_regex(r"o.a").unwrap(/*:test:*/);
+        assert_eq!(re.as_str(), r"^(?:o.a)$");
+
+        assert!(!re.is_match("foobar"));
+        assert!(!re.is_match("ooba"));
+        assert!(!re.is_match("obar"));
+        assert!(re.is_match("oba"));
+    }
+
+    #[test]
+    fn test_full_haystack_pattern_anchored() {
+        let re = new_full_haystack_regex(r"^o.a$").unwrap(/*:test:*/);
+        assert_eq!(re.as_str(), r"^(?:^o.a$)$");
+
+        assert!(!re.is_match("foobar"));
+        assert!(!re.is_match("ooba"));
+        assert!(!re.is_match("obar"));
+        assert!(re.is_match("oba"));
+    }
+
+    #[test]
+    fn test_full_haystack_pattern_peeled() {
+        let re_str = r"^(?:o.a)$";
+        let re = new_full_haystack_regex(re_str).unwrap(/*:test:*/);
+        assert_eq!(re.as_str(), r"^(?:^(?:o.a)$)$");
+
+        assert!(!re.is_match("foobar"));
+        assert!(!re.is_match("ooba"));
+        assert!(!re.is_match("obar"));
+        assert!(re.is_match("oba"));
+
+        assert_eq!(peeled_pattern(&re), re_str);
+    }
+
+    #[test]
+    fn test_full_haystack_patterns() {
+        let re_set = new_full_haystack_regex_set([r".*foo", r"bar.*"]).unwrap(/*:test:*/);
+        assert_eq!(re_set.patterns(), [r"^(?:.*foo)$", r"^(?:bar.*)$"]);
+
+        assert!(!re_set.is_match("foobar"));
+        assert!(re_set.is_match("foo"));
+        assert!(re_set.is_match("bar"));
+    }
+
+    #[test]
+    fn test_full_haystack_patterns_anchored() {
+        let re_set = new_full_haystack_regex_set([r"^.*foo$", r"^bar.*$"]).unwrap(/*:test:*/);
+        assert_eq!(re_set.patterns(), [r"^(?:^.*foo$)$", r"^(?:^bar.*$)$"]);
+
+        assert!(!re_set.is_match("foobar"));
+        assert!(re_set.is_match("foo"));
+        assert!(re_set.is_match("bar"));
+    }
+
+    #[test]
+    fn test_full_haystack_patterns_peeled() {
+        let re_set_str = [r"^(?:.*foo)$", r"^(?:bar.*)$"];
+        let re_set = new_full_haystack_regex_set(re_set_str).unwrap(/*:test:*/);
+        assert_eq!(
+            re_set.patterns(),
+            [r"^(?:^(?:.*foo)$)$", r"^(?:^(?:bar.*)$)$"]
+        );
+
+        assert!(!re_set.is_match("foobar"));
+        assert!(re_set.is_match("foo"));
+        assert!(re_set.is_match("bar"));
+
+        assert_eq!(peeled_patterns(&re_set), re_set_str);
+    }
+}

--- a/tackler-rs/src/regex/serde.rs
+++ b/tackler-rs/src/regex/serde.rs
@@ -1,0 +1,51 @@
+/*
+ * This file is licensed under either of
+ *  - Apache License, Version 2.0
+ * OR
+ *  - MIT license
+ * at your option.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ **************************************************************************
+ *
+ * Apache License header
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+

--- a/tackler-rs/src/regex/serde.rs
+++ b/tackler-rs/src/regex/serde.rs
@@ -49,3 +49,22 @@
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/// Full Haystack matcher serializer and deserializer
+///
+/// # Example
+///
+/// ```rust
+/// use regex::Regex;
+/// use serde::{Deserialize, Serialize};
+/// use tackler_rs::regex::serde::full_haystack_matcher;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct Account {
+///     #[serde(with = "full_haystack_matcher")]
+///     regex: Regex,
+/// }
+///
+/// #
+/// # fn main() {}
+/// ```
+pub mod full_haystack_matcher;

--- a/tackler-rs/src/regex/serde/full_haystack_matcher.rs
+++ b/tackler-rs/src/regex/serde/full_haystack_matcher.rs
@@ -1,0 +1,51 @@
+/*
+ * This file is licensed under either of
+ *  - Apache License, Version 2.0
+ * OR
+ *  - MIT license
+ * at your option.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ **************************************************************************
+ *
+ * Apache License header
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright 2024 E257.FI
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the “Software”),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+

--- a/tackler-rs/src/regex/serde/full_haystack_matcher.rs
+++ b/tackler-rs/src/regex/serde/full_haystack_matcher.rs
@@ -49,3 +49,119 @@
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+//
+// This code is based on: https://github.com/tailhook/serde-regex,
+// which is licensed as Apache-2.0 OR MIT
+//
+
+use regex::Regex;
+use std::{
+    borrow::Cow,
+    hash::Hash,
+    ops::{Deref, DerefMut},
+};
+
+use crate::regex::{new_full_haystack_regex, peeled_pattern};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+/// A wrapper type which implements `Serialize` and `Deserialize` for
+/// types involving `Regex`
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub struct Serde<T>(pub T);
+
+impl<'de> Deserialize<'de> for Serde<Regex> {
+    fn deserialize<D>(d: D) -> Result<Serde<Regex>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = <Cow<str>>::deserialize(d)?;
+
+        match new_full_haystack_regex(s.as_ref()) {
+            Ok(regex) => Ok(Serde(regex)),
+            Err(err) => Err(D::Error::custom(err)),
+        }
+    }
+}
+
+/// Deserialize function, see crate docs to see how to use it
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    Serde<T>: Deserialize<'de>,
+{
+    Serde::deserialize(deserializer).map(|x| x.0)
+}
+
+/// Serialize function, see crate docs to see how to use it
+pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    for<'a> Serde<&'a T>: Serialize,
+{
+    Serde(value).serialize(serializer)
+}
+
+impl<T> Deref for Serde<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Serde<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> Serde<T> {
+    /// Consumes the `Serde`, returning the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for Serde<T> {
+    fn from(val: T) -> Serde<T> {
+        Serde(val)
+    }
+}
+
+impl Serialize for Serde<&Regex> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        peeled_pattern(self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for Serde<Regex> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        peeled_pattern(&self.0).serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::regex::into_full_haystack_pattern;
+    use regex::Regex;
+    use serde_json::{from_str, to_string};
+
+    const SAMPLE: &str = r#"[a-z"\]]+\d{1,10}""#;
+    const SAMPLE_JSON: &str = r#""[a-z\"\\]]+\\d{1,10}\"""#;
+
+    #[test]
+    fn test_regex() {
+        let re: Serde<Regex> = from_str(SAMPLE_JSON).unwrap();
+
+        assert_eq!(re.as_str(), into_full_haystack_pattern(SAMPLE));
+        assert_eq!(to_string(&re).unwrap(), SAMPLE_JSON);
+    }
+}

--- a/tests/sh/audit.sh
+++ b/tests/sh/audit.sh
@@ -64,6 +64,27 @@ cmp_result $module $test_name txn equity
 echo ": ok"
 
 #
+# audit-1E1-03
+#
+# test: 5c34d752-8d17-40df-be91-5dc1b107478e
+rm -f $OUTPUT_DIR/*
+test_name=audit-1E1-03
+echo "test: $module/$test_name: "
+
+$TACKLER_SH \
+    --output.dir $OUTPUT_DIR \
+    --output.prefix $test_name \
+    --config $SUITE_PATH/audit/audit.toml \
+    --accounts "e" "a"
+
+echo -n "check:"
+cmp_result $module $test_name txt bal
+cmp_result $module $test_name txt balgrp
+cmp_result $module $test_name txt reg
+echo ": ok"
+
+
+#
 # audit-1E2-01
 #
 # test: 4e8e1d79-bbb5-4e6f-9072-d7e3c5b8c7ea
@@ -270,7 +291,7 @@ $TACKLER_SH \
     --input.git.repository $SUITE_PATH/audit/audit-repo.git \
     --input.git.dir "txns" \
     --input.git.ref "txns-1E2" \
-    --accounts "^e:.*" \
+    --accounts "e:.*" \
     --api-filter-def "$filter_def"
 
 echo -n "check:"


### PR DESCRIPTION
Tackler-Mk1 (and JDK) regex is full haystack matching by default 

Implement the same logic and keep Account Selector Checksums the same
